### PR TITLE
Fix MacOS instructions in README; fix import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You will have to download the code and use
 ```commandline
 python3 -m venv venv
 source venv/bin/activate
-pip install requirements.txt
+pip install -r requirements.txt
 python main.py
 ```
 to run it directly. Or generate the executable by running `python pyinstaller.py`. This will generate 

--- a/src/gui/about_page.py
+++ b/src/gui/about_page.py
@@ -20,7 +20,7 @@ import pathlib
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QTextBrowser, QVBoxLayout, QWidget
 
-from img.img_path import img_path
+from src.img.img_path import img_path
 
 
 class AboutPage(QWidget):


### PR DESCRIPTION
The import statement change resolves an error when executing from source on MacOS.

```
 % python3 main.py
Traceback (most recent call last):
  File "/Users/booty/code/hdf5-viewer/main.py", line 23, in <module>
    from src.gui.main_window import MainWindow
  File "/Users/booty/code/hdf5-viewer/src/gui/main_window.py", line 58, in <module>
    from src.gui.about_page import AboutPage
  File "/Users/booty/code/hdf5-viewer/src/gui/about_page.py", line 23, in <module>
    from img.img_path import img_path
ModuleNotFoundError: No module named 'img'
```